### PR TITLE
bugfix/accurics_remediation_30325527271462094 - Auto Generated Pull Request From Accurics

### DIFF
--- a/pkg/iac-providers/terraform/v15/testdata/moduleconfigs/ecs/main.tf
+++ b/pkg/iac-providers/terraform/v15/testdata/moduleconfigs/ecs/main.tf
@@ -1,5 +1,5 @@
 resource "aws_ecs_task_definition" "instanceNotInVpc" {
   family                = "service"
-  network_mode          = "bridge"
+  network_mode          = "awsvpc"
   container_definitions = file("ecs/service.json")
 }


### PR DESCRIPTION
You can improve the security posture of your VPC by configuring Amazon ECS to use an interface VPC endpoint. Interface endpoints are powered by AWS PrivateLink, a technology that enables you to privately access Amazon ECS APIs by using private IP addresses. AWS PrivateLink restricts all network traffic between your VPC and Amazon ECS to the Amazon network. You don't need an internet gateway, a NAT device, or a virtual private gateway.